### PR TITLE
refactor: use _serviceProvider binding to retrieve LookupService

### DIFF
--- a/Snippets/helperFunctions.groovy
+++ b/Snippets/helperFunctions.groovy
@@ -1,11 +1,10 @@
 import eu.esdihumboldt.hale.common.lookup.*;
-import eu.esdihumboldt.hale.ui.HaleUI;
 import eu.esdihumboldt.hale.common.core.io.*;
 import java.text.SimpleDateFormat;
 
 def getLookupTableValue(value, tableId) {
 	// retrieve Lookup table
-	LookupService ls = HaleUI.getServiceProvider().getService(LookupService.class)
+	LookupService ls = _serviceProvider.getService(LookupService.class)
 	LookupTableInfo lithTable = ls.getTable(tableId)
 	def table = lithTable.getTable()
 
@@ -16,7 +15,7 @@ def getLookupTableValue(value, tableId) {
 
 def getLookupTableKeys(tableId) {
 	// retrieve Lookup table
-	LookupService ls = HaleUI.getServiceProvider().getService(LookupService.class)
+	LookupService ls = _serviceProvider.getService(LookupService.class)
 	LookupTableInfo lithTable = ls.getTable(tableId)
 	def table = lithTable.getTable()
 


### PR DESCRIPTION
Use the [new `_serviceProvider` Groovy binding](https://github.com/halestudio/hale/pull/1166) to instantiate `LookupService`. This allows to automate the transformation with gradle-hale-
plugin.

@annat2022 To use the updated alignment, the [most recent snapshot build of hale»studio](https://github.com/halestudio/hale/actions/runs/9003849685/artifacts/1484569824) must be used, otherwise the `_serviceProvider` binding will not be available.

SVC-1812