### PR TITLE
feat: add default export configuration to Major Roads DF7_10 alignments

### DIFF
--- a/Aggregation/MajorRoads/DF7_10_Roads_Aggregations.halex
+++ b/Aggregation/MajorRoads/DF7_10_Roads_Aggregations.halex
@@ -30,6 +30,16 @@
         <setting name="contentType">eu.esdihumboldt.hale.io.groovy</setting>
         <setting name="autoReload">true</setting>
     </resource>
+    <export-config name="default">
+        <configuration action-id="eu.esdihumboldt.hale.io.instance.write.transformed" provider-id="eu.esdihumboldt.hale.io.xls.writer.instance">
+            <setting name="charset">UTF-8</setting>
+            <setting name="meta.description"></setting>
+            <setting name="useSchema">true</setting>
+            <setting name="selectedExportType">NoiseActionPlanMajorRoad,NAP_MajorRoad,NAP_MajorRoadCompetentAuthority,NAP_MajorRoadLimitValues,NAP_RoadMappingResultDetail,NAP_RoadReductionMeasure,NAP_RoadReductionHealthImpact_1,NAP_RoadReductionHealthImpact_2,NAP_RoadReductionHealthImpact_3,ESTATUnitReference,DatasetDefaultProperties,CodelistProperties</setting>
+            <setting name="contentType">eu.esdihumboldt.hale.io.xls.xlsx</setting>
+            <setting name="solveNestedProperties">true</setting>
+        </configuration>
+    </export-config>
     <file name="alignment.xml" location="DF7_10_Roads_Aggregations.halex.alignment.xml"/>
     <file name="styles.sld" location="DF7_10_Roads_Aggregations.halex.styles.sld"/>
     <property name="defaultGeometry:{http://www.xplanung.de/xplangml/5/4}XP_PPOType/1">{http://www.opengis.net/gml/3.2}boundedBy</property>

--- a/Validation/MajorRoads/UBA-DE_HVS_to_END_DF7_10_Roads.halex
+++ b/Validation/MajorRoads/UBA-DE_HVS_to_END_DF7_10_Roads.halex
@@ -136,6 +136,16 @@
         <setting name="separator">,</setting>
         <setting name="escape">\</setting>
     </resource>
+    <export-config name="default">
+        <configuration action-id="eu.esdihumboldt.hale.io.instance.write.transformed" provider-id="eu.esdihumboldt.hale.io.xls.writer.instance">
+            <setting name="charset">UTF-8</setting>
+            <setting name="meta.description"></setting>
+            <setting name="useSchema">true</setting>
+            <setting name="selectedExportType">NoiseActionPlanMajorRoad,NAP_MajorRoad,NAP_MajorRoadCompetentAuthority,NAP_MajorRoadLimitValues,NAP_RoadMappingResultDetail,NAP_RoadReductionMeasure,NAP_RoadReductionHealthImpact_1,NAP_RoadReductionHealthImpact_2,NAP_RoadReductionHealthImpact_3,ESTATUnitReference,DatasetDefaultProperties,CodelistProperties</setting>
+            <setting name="contentType">eu.esdihumboldt.hale.io.xls.xlsx</setting>
+            <setting name="solveNestedProperties">true</setting>
+        </configuration>
+    </export-config>
     <file name="alignment.xml" location="UBA-DE_HVS_to_END_DF7_10_Roads.halex.alignment.xml"/>
     <file name="styles.sld" location="UBA-DE_HVS_to_END_DF7_10_Roads.halex.styles.sld"/>
     <complex-property name="variables">


### PR DESCRIPTION
Adds an export configuration with the name `default` to the Major Roads DF7_10 alignments that exports the sheets in the same order as they appear in the EEA template.

SVC-1812