### PR TITLE
fix: correct order of sheets in export config 'default'

### DIFF
--- a/Aggregation/Agglomerations/DF7_10_Agglomerations_Aggregations.halex
+++ b/Aggregation/Agglomerations/DF7_10_Agglomerations_Aggregations.halex
@@ -35,7 +35,7 @@
             <setting name="charset">UTF-8</setting>
             <setting name="meta.description"></setting>
             <setting name="useSchema">true</setting>
-            <setting name="selectedExportType">NAP_AggCompetentAuthority,NAP_AggMappingResultDetail,NAP_AggReductionHealthImpact_3,DatasetDefaultProperties,NAP_Agglomeration,NAP_AggReductionHealthImpact_2,CodelistProperties,NAP_AggReductionHealthImpact_1,NAP_AggReductionMeasure,NAP_AggLimitValues,NoiseActionPlanAgglomeration,</setting>
+            <setting name="selectedExportType">NoiseActionPlanAgglomeration,NAP_Agglomeration,NAP_AggCompetentAuthority,NAP_AggLimitValues,NAP_AggMappingResultDetail,NAP_AggReductionMeasure,NAP_AggReductionHealthImpact_1,NAP_AggReductionHealthImpact_2,NAP_AggReductionHealthImpact_3,DatasetDefaultProperties,CodelistProperties</setting>
             <setting name="contentType">eu.esdihumboldt.hale.io.xls.xlsx</setting>
             <setting name="solveNestedProperties">true</setting>
             <setting name="ignoreEmptyFeaturetypes">false</setting>

--- a/Validation/Agglomerations/UBA-DE_AGG_to_END_DF7_10_Agglomerations.halex
+++ b/Validation/Agglomerations/UBA-DE_AGG_to_END_DF7_10_Agglomerations.halex
@@ -155,7 +155,7 @@
             <setting name="charset">UTF-8</setting>
             <setting name="meta.description"></setting>
             <setting name="useSchema">true</setting>
-            <setting name="selectedExportType">NAP_AggCompetentAuthority,NAP_AggMappingResultDetail,NAP_AggReductionHealthImpact_3,DatasetDefaultProperties,NAP_Agglomeration,NAP_AggReductionHealthImpact_2,CodelistProperties,NAP_AggReductionHealthImpact_1,NAP_AggReductionMeasure,NAP_AggLimitValues,NoiseActionPlanAgglomeration</setting>
+            <setting name="selectedExportType">NoiseActionPlanAgglomeration,NAP_Agglomeration,NAP_AggCompetentAuthority,NAP_AggLimitValues,NAP_AggMappingResultDetail,NAP_AggReductionMeasure,NAP_AggReductionHealthImpact_1,NAP_AggReductionHealthImpact_2,NAP_AggReductionHealthImpact_3,DatasetDefaultProperties,CodelistProperties</setting>
             <setting name="contentType">eu.esdihumboldt.hale.io.xls.xlsx</setting>
             <setting name="solveNestedProperties">true</setting>
             <setting name="ignoreEmptyFeaturetypes">false</setting>


### PR DESCRIPTION
Order of sheets is corrected to be aligned with the EEA template.

SVC-1800