### PR TITLE
fix: remove validation if table 'QuietAreaDocumentation' is present

### DIFF
--- a/Aggregation/QuietAreas/DF7_10_QuietAreas_Aggregations.halex.alignment.xml
+++ b/Aggregation/QuietAreas/DF7_10_QuietAreas_Aggregations.halex.alignment.xml
@@ -53,7 +53,6 @@ codelistProperty('QuietArea', 'quietAreaId_identifierScheme', 'http://dd.eionet.
 // Check if any tables were present that are mandatory&#13;
 def expectedTypes = [&#13;
 	'QuietArea':'TB1',&#13;
-	'QuietAreaDocumentation':'TB28',&#13;
 ]&#13;
 def presentTypes&#13;
 &#13;


### PR DESCRIPTION
Previously, this validation rule was listed in the official list by EEA and therefore added to the alignment. But this the table 'QuietAreaDocumentation' is optional and with the updated validation rules in July 2024 the rules was removed.

SVC-1696